### PR TITLE
Fix: openSourceSaveDto의 clientId를 openSourceId로 수정

### DIFF
--- a/src/main/kotlin/com/osscube/api/domain/dto/OpenSourceSaveResponseDto.kt
+++ b/src/main/kotlin/com/osscube/api/domain/dto/OpenSourceSaveResponseDto.kt
@@ -3,7 +3,7 @@ package com.osscube.api.domain.dto
 import com.osscube.api.domain.model.entity.OpenSource
 
 class OpenSourceSaveResponseDto(
-    val clientId: String,
+    val openSourceId: String,
     val name: String,
     val originUrl: String
 ) {

--- a/src/test/kotlin/com/osscube/api/application/controller/OpenSourceControllerTest.kt
+++ b/src/test/kotlin/com/osscube/api/application/controller/OpenSourceControllerTest.kt
@@ -54,7 +54,7 @@ class OpenSourceControllerTest : TestContainers() {
                     .content(objectMapper.writeValueAsString(request))
             )
             .andExpect { status().isCreated }
-            .andExpect(jsonPath("$.openSource.clientId").value(Matchers.isA(String::class.java), String::class.java))
+            .andExpect(jsonPath("$.openSource.openSourceId").value(Matchers.isA(String::class.java), String::class.java))
             .andExpect(jsonPath("$.openSource.name").value("name"))
             .andExpect(jsonPath("$.openSource.originUrl").value("origin url"))
     }

--- a/src/test/kotlin/com/osscube/api/domain/service/OpenSourceServiceTest.kt
+++ b/src/test/kotlin/com/osscube/api/domain/service/OpenSourceServiceTest.kt
@@ -40,7 +40,7 @@ class OpenSourceServiceTest : TestContainers() {
         val responseDto = openSourceService.saveOpenSource(requestDto)
 
         // then
-        assertThat(responseDto.clientId)
+        assertThat(responseDto.openSourceId)
             .hasSize(36)
         assertThat(responseDto)
             .extracting("name", "originUrl")


### PR DESCRIPTION
close #3 